### PR TITLE
chore: migrate obsolete workflow set-output to environment files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
-          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: Setup pnpm cache
         uses: actions/cache@v3


### PR DESCRIPTION
More info: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/